### PR TITLE
feat(mcp): 从SSE迁移到Streamable HTTP传输协议

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -6,6 +6,3 @@ WRITEATHON_TOKEN=your_integration_token_here
 # 服务器配置
 PORT=3000
 HOST=localhost
-
-# MCP配置
-MCP_API_KEY=your_mcp_api_key_here

--- a/README.md
+++ b/README.md
@@ -12,19 +12,21 @@
 ## 安装
 
 ```bash
-# 先安装nodejs和npm
+# 1. 克隆仓库
+git clone https://github.com/Hcs66/writeathon-mcp.git
+cd writeathon-mcp-server
 
-# 确保使用Node.js 20+以上版本，若同时安装多个版本，可先安装nvm
-nvm use 20
+# 2. 安装nodejs
+# 确保使用Node.js 20+以上版本，若同时存在多个版本，可先安装nvm并切换
 
-# 安装依赖，请确保文件夹有读写权限
+# 安装依赖，确保文件夹有读写权限
 npm install
 ```
 
 ## 配置
 
 1. 复制`.env.example`文件为`.env.prod`
-2. 编辑`.env.prod`文件，填入你的Writeathon用户ID、集成Token（web→设置→集成）和MCP API密钥(自定义)
+2. 编辑`.env.prod`文件，填入你的Writeathon用户ID、集成Token（web→设置→集成）
 
 ```
 # API配置
@@ -35,9 +37,6 @@ WRITEATHON_TOKEN=your_integration_token_here
 # 服务器配置
 PORT=3000
 HOST=localhost
-
-# MCP配置
-MCP_API_KEY=your_mcp_api_key_here
 ```
 
 ## 运行
@@ -54,6 +53,23 @@ npm start
 - 服务器将在`HOST:PORT`上运行。
 - MCP服务将在`HOST:PORT+1`上运行。
 - MCP SSE地址为`HOST:PORT+1/mcp/sse`。
+
+## 在Claude/Trae等平台使用
+通过复制`mcp.json`内容手动创建MCP
+
+其中`HOST`和`PORT`为.env配置文件中的HOST和PORT+1，如HOST=localhost,PORT=3000，则url为`http://localhost:3001/mcp`
+
+```json
+{
+  "mcpServers": {
+    "writeathon": {
+      "type": "streamable-http",
+      "url": "http://HOST:PORT/mcp",
+      "note": "For Streamable HTTP connections, add this URL directly in your MCP Client"
+    }
+  }
+}
+```
 
 ## API接口
 

--- a/mcp.json
+++ b/mcp.json
@@ -1,0 +1,9 @@
+{
+  "mcpServers": {
+    "writeathon": {
+      "type": "streamable-http",
+      "url": "http://HOST:PORT/mcp",
+      "note": "For Streamable HTTP connections, add this URL directly in your MCP Client"
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   "license": "ISC",
   "description": "",
   "dependencies": {
-    "@modelcontextprotocol/sdk": "^1.9.0",
+    "@modelcontextprotocol/sdk": "^1.13.0",
     "@types/express": "^5.0.1",
     "@types/node": "^22.14.1",
     "axios": "^1.8.4",

--- a/src/services/mcp-service.ts
+++ b/src/services/mcp-service.ts
@@ -12,11 +12,16 @@ import { z } from "zod";
 import { config } from "../config/env";
 import { WriteathonApiClient } from "./api-client";
 
+import { randomUUID } from "node:crypto";
+import { StreamableHTTPServerTransport } from "@modelcontextprotocol/sdk/server/streamableHttp.js";
+import { isInitializeRequest } from "@modelcontextprotocol/sdk/types.js";
+
 export class WriteathonMCPService {
   private server: McpServer;
   private apiClient: WriteathonApiClient;
   private expressApp: express.Express;
-  private transports: { [sessionId: string]: SSEServerTransport } = {};
+  private transports: { [sessionId: string]: StreamableHTTPServerTransport } =
+    {};
   private httpServer: any;
 
   constructor() {
@@ -39,7 +44,10 @@ export class WriteathonMCPService {
     this.configurePrompts();
 
     // 配置SSE端点
-    this.configureSSEEndpoints();
+    //this.configureSSEEndpoints();
+
+    // 配置Streamable HTTP 端点
+    this.configureStreamableHTTPEndpoints();
   }
 
   /**
@@ -73,7 +81,7 @@ export class WriteathonMCPService {
       ),
       async (uri, params) => {
         const excludeDateTitle = params.exclude_date_title === "true";
-                
+
         const response = await this.apiClient.getRecentCards({
           exclude_date_title: excludeDateTitle,
         });
@@ -150,6 +158,7 @@ export class WriteathonMCPService {
     // 创建卡片工具
     this.server.tool(
       "create-card",
+      "创建卡片",
       {
         title: z.string().optional(),
         content: z.string().max(5000, "内容最大长度为5000个字符"),
@@ -173,6 +182,7 @@ export class WriteathonMCPService {
     // 获取卡片工具
     this.server.tool(
       "get-card",
+      "获取卡片",
       {
         title: z.string().optional(),
         id: z.string().optional(),
@@ -206,6 +216,7 @@ export class WriteathonMCPService {
     // 获取写作拾贝工具
     this.server.tool(
       "get-writing-pick",
+      "写作拾贝",
       {
         type: z.enum(["all", "page", "card"]).optional(),
         limit: z.number().min(1).max(10).optional(),
@@ -241,6 +252,7 @@ export class WriteathonMCPService {
     // 卡片创建提示
     this.server.prompt(
       "create-card-prompt",
+      "根据内容创建一张卡片",
       { content: z.string() },
       ({ content }) => ({
         messages: [
@@ -258,6 +270,7 @@ export class WriteathonMCPService {
     // 写作拾贝提示
     this.server.prompt(
       "writing-pick-prompt",
+      "获取写作拾贝",
       { type: z.enum(["all", "page", "card"]).optional() },
       ({ type }) => ({
         messages: [
@@ -275,53 +288,139 @@ export class WriteathonMCPService {
     );
   }
 
+  // Reusable handler for GET and DELETE requests
+  private handleSessionRequest = async (
+    req: express.Request,
+    res: express.Response
+  ) => {
+    const sessionId = req.headers["mcp-session-id"] as string | undefined;
+    if (!sessionId || !this.transports[sessionId]) {
+      res.status(400).send("Invalid or missing session ID");
+      return;
+    }
+
+    const transport = this.transports[sessionId];
+    await transport.handleRequest(req, res);
+  };
+
   /**
-   * 配置SSE端点
+   * 配置Streamable HTTP 端点
    */
-  private configureSSEEndpoints(): void {
-    // SSE端点，用于建立服务器发送事件连接
-    this.expressApp.get("/mcp/sse", async (req: Request, res: Response) => {
+  private configureStreamableHTTPEndpoints(): void {
+    // Handle POST requests for client-to-server communication
+    this.expressApp.post("/mcp", async (req, res) => {
       // 验证Bearer Token
       const authHeader = req.headers.authorization;
-      const expectedToken = `Bearer ${config.mcp.apiKey}`;
+      // const expectedToken = `Bearer ${config.mcp.apiKey}`;
 
-      if (!authHeader || authHeader !== expectedToken) {
-        res.status(401).send("Unauthorized: Invalid API Key");
+      // if (!authHeader || authHeader !== expectedToken) {
+      //   res.status(401).send("Unauthorized: Invalid API Key");
+      //   return;
+      // }
+      // Check for existing session ID
+      const sessionId = req.headers["mcp-session-id"] as string | undefined;
+      let transport: StreamableHTTPServerTransport;
+
+      if (sessionId && this.transports[sessionId]) {
+        // Reuse existing transport
+        transport = this.transports[sessionId];
+      } else if (!sessionId && isInitializeRequest(req.body)) {
+        // New initialization request
+        transport = new StreamableHTTPServerTransport({
+          sessionIdGenerator: () => randomUUID(),
+          onsessioninitialized: (sessionId) => {
+            // Store the transport by session ID
+            this.transports[sessionId] = transport;
+          },
+        });
+
+        // Clean up transport when closed
+        transport.onclose = () => {
+          if (transport.sessionId) {
+            delete this.transports[transport.sessionId];
+          }
+        };
+
+        // ... set up server resources, tools, and prompts ...
+
+        // Connect to the MCP server
+        await this.server.connect(transport);
+      } else {
+        // Invalid request
+        res.status(400).json({
+          jsonrpc: "2.0",
+          error: {
+            code: -32000,
+            message: "Bad Request: No valid session ID provided",
+          },
+          id: null,
+        });
         return;
       }
 
-      const transport = new SSEServerTransport("/mcp/messages", res);
-      this.transports[transport.sessionId] = transport;
-      res.on("close", () => {
-        delete this.transports[transport.sessionId];
-      });
-      await this.server.connect(transport);
+      // Handle the request
+      await transport.handleRequest(req, res, req.body);
     });
 
-    // 消息端点，用于接收客户端消息
-    this.expressApp.post(
-      "/mcp/messages",
-      async (req: Request, res: Response) => {
-        const sessionId = req.query.sessionId as string;
-        const transport = this.transports[sessionId];
+    // Handle GET requests for server-to-client notifications via SSE
+    this.expressApp.get("/mcp", this.handleSessionRequest);
 
-        if (transport) {
-          // using `await transport.handlePostMessage(req, res)` will cause
-          // `SSE transport error: Error: Error POSTing to endpoint (HTTP 400): InternalServerError: stream is not readable`
-          // on the client side
-          // https://medium.com/@itsuki.enjoy/mcp-server-and-client-with-sse-the-new-streamable-http-d860850d9d9d
-          await transport.handlePostMessage(req, res, req.body);
-        } else {
-          res.status(400).send("No transport found for sessionId");
-        }
-      }
-    );
+    // Handle DELETE requests for session termination
+    this.expressApp.delete("/mcp", this.handleSessionRequest);
 
     // 健康检查端点
     this.expressApp.get("/mcp/health", (_, res) => {
       res.status(200).json({ status: "ok" });
     });
   }
+
+  /**
+   * 配置SSE端点
+   */
+  // private configureSSEEndpoints(): void {
+  //   // SSE端点，用于建立服务器发送事件连接
+  //   this.expressApp.get("/mcp/sse", async (req: Request, res: Response) => {
+  //     // 验证Bearer Token
+  //     const authHeader = req.headers.authorization;
+  //     const expectedToken = `Bearer ${config.mcp.apiKey}`;
+
+  //     if (!authHeader || authHeader !== expectedToken) {
+  //       res.status(401).send("Unauthorized: Invalid API Key");
+  //       return;
+  //     }
+
+  //     const transport = new SSEServerTransport("/mcp/messages", res);
+  //     this.transports[transport.sessionId] = transport;
+  //     res.on("close", () => {
+  //       delete this.transports[transport.sessionId];
+  //     });
+  //     await this.server.connect(transport);
+  //   });
+
+  //   // 消息端点，用于接收客户端消息
+  //   this.expressApp.post(
+  //     "/mcp/messages",
+  //     async (req: Request, res: Response) => {
+  //       const sessionId = req.query.sessionId as string;
+  //       const transport = this.transports[sessionId];
+
+  //       if (transport) {
+  //         // using `await transport.handlePostMessage(req, res)` will cause
+  //         // `SSE transport error: Error: Error POSTing to endpoint (HTTP 400): InternalServerError: stream is not readable`
+  //         // on the client side
+  //         // https://medium.com/@itsuki.enjoy/mcp-server-and-client-with-sse-the-new-streamable-http-d860850d9d9d
+  //         await transport.handlePostMessage(req, res, req.body);
+  //       } else {
+  //         res.status(400).send("No transport found for sessionId");
+  //       }
+  //     }
+  //   );
+
+  //   // 健康检查端点
+  //   this.expressApp.get("/mcp/health", (_, res) => {
+  //     res.status(200).json({ status: "ok" });
+  //   });
+  // }
 
   /**
    * 启动MCP服务


### PR DESCRIPTION
更新MCP服务以使用Streamable HTTP协议替代SSE
添加新的mcp.json配置文件示例
更新README文档说明新的配置方式
升级@modelcontextprotocol/sdk到1.13.0版本
移除不再需要的MCP_API_KEY配置